### PR TITLE
Add UE 4.26.1 and C++17 support.

### DIFF
--- a/Source/SDFutureExtensions/Private/FutureExtensionsTypeTraits.h
+++ b/Source/SDFutureExtensions/Private/FutureExtensionsTypeTraits.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "Templates/IntegralConstant.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 namespace SD
 {
@@ -173,13 +174,25 @@ namespace SD
 		template<typename F, typename P>
 		struct TContinuationFunctorReturnType<F, P, typename TEnableIf<!TIsVoidType<P>::Value>::Type>
 		{
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 26 && ENGINE_PATCH_VERSION >= 1
+			using ReturnType = typename TInvokeResult<typename std::decay_t<F>, P>::Type;
+#elif /* C++17 */ __cplusplus >= 201703L || /* MSVC */ (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+			using ReturnType = std::invoke_result_t<typename std::decay_t<F>, P>;
+#else
 			using ReturnType = std::result_of_t<typename std::decay_t<F>(P)>;
+#endif
 		};
 
 		template<typename F, typename P>
 		struct TContinuationFunctorReturnType<F, P, typename TEnableIf<TIsVoidType<P>::Value>::Type>
 		{
+#if ENGINE_MAJOR_VERSION >= 4 && ENGINE_MINOR_VERSION >= 26 && ENGINE_PATCH_VERSION >= 1
+			using ReturnType = typename TInvokeResult<typename std::decay_t<F>>::Type;
+#elif /* C++17 */ __cplusplus >= 201703L || /* MSVC */ (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+			using ReturnType = std::invoke_result_t<typename std::decay_t<F>>;
+#else
 			using ReturnType = std::result_of_t<typename std::decay_t<F>()>;
+#endif
 		};
 
 		//Aliases for supported specializations of continuation functors


### PR DESCRIPTION
For UE4 versions 4.26.1 and newer use the `TInvokeResult` type trait provided by UE4.
For previous versions, check if the project is using C++17 and use `std::invoke_result_t` instead of `std::result_of_t` as it is deprecated.

MSVC might not define the correct value for `__cplusplus` depending on the version used so the `_MSVC_LANG` macro must be checked as well.