### PR TITLE
Updated FutureContinuationDetails template in order to fix UE5 issue

### DIFF
--- a/Source/SDFutureExtensions/Public/ExpectedFuture.h
+++ b/Source/SDFutureExtensions/Public/ExpectedFuture.h
@@ -232,19 +232,19 @@ namespace SD
 		};
 
 		template<typename T>
-		class TWeakRefType<T, typename std::enable_if<std::is_base_of<TSharedFromThis<T>, T>::value>::type> : TWeakPtr<T>
+		class TWeakRefType<T, typename std::enable_if<std::is_base_of<TSharedFromThis<T, ESPMode::NotThreadSafe>, T>::value>::type> : TWeakPtr<T, ESPMode::NotThreadSafe>
 		{
 		public:
-			explicit TWeakRefType(T* Obj) : TWeakPtr<T>(GetWeakPtr(Obj)) {}
-			static TWeakPtr<T> GetWeakPtr(T* Obj)
+			explicit TWeakRefType(T* Obj) : TWeakPtr<T, ESPMode::NotThreadSafe>(GetWeakPtr(Obj)) {}
+			static TWeakPtr<T, ESPMode::NotThreadSafe> GetWeakPtr(T* Obj)
 			{
 				if (Obj)
 				{
 					return Obj->AsShared();
 				}
-				return TWeakPtr<T>();
+				return TWeakPtr<T, ESPMode::NotThreadSafe>();
 			}
-			TSharedPtr<T> Pin() const { return TWeakPtr<T>::Pin(); }
+			TSharedPtr<T, ESPMode::NotThreadSafe> Pin() const { return TWeakPtr<T, ESPMode::NotThreadSafe>::Pin(); }
 		};
 
 		template<typename T>


### PR DESCRIPTION
In UE5, the default ESPMode is ThreadSafe (in contrast UE4), so we have to specialize explicitly in both cases to provide support to both engines' versions at the same time.