### PR TITLE
Fixed some incorrect use of MoveTemp with forwarding references, replaced with Forward calls.

### DIFF
--- a/Source/SDFutureExtensions/Private/FutureExtensionTaskGraph.h
+++ b/Source/SDFutureExtensions/Private/FutureExtensionTaskGraph.h
@@ -323,7 +323,7 @@ namespace SD
 			TExpectedFutureInitTask(F&& InFunc, const SharedPromiseRef& InPromise,
 				WeakSharedCancellationHandlePtr WeakCancellationHandle)
 				: SharedPromise(InPromise)
-				, InitFunctor(MoveTemp(InFunc))
+				, InitFunctor(Forward<F>(InFunc))
 			{
 				TryAddPromiseToCancellationHandle(WeakCancellationHandle, SharedPromise);
 			}
@@ -360,7 +360,7 @@ namespace SD
 				TLifetimeMonitor&& InLifetimeMonitor)
 				: SharedPromise(InPromise)
 				, PrevFuture(InPrevFuture)
-				, ContinuationFunction(MoveTemp(InFunction))
+				, ContinuationFunction(Forward<F>(InFunction))
 				, LifetimeMonitor(MoveTemp(InLifetimeMonitor))
 			{
 				TryAddPromiseToCancellationHandle(WeakCancellationHandle, SharedPromise);
@@ -461,7 +461,7 @@ namespace SD
 			TExpectedFutureInitQueuedWork(F&& InFunc, const SharedPromiseRef& InPromise,
 				WeakSharedCancellationHandlePtr WeakCancellationHandle)
 				: TExpectedFutureQueuedWork<R>(InPromise, WeakCancellationHandle)
-				, InitFunctor(MoveTemp(InFunc))
+				, InitFunctor(Forward<F>(InFunc))
 			{
 			}
 
@@ -495,7 +495,7 @@ namespace SD
 				TLifetimeMonitor&& InLifetimeMonitor)
 				: TExpectedFutureQueuedWork<R>(InPromise, WeakCancellationHandle)
 				, PrevFuture(InPrevFuture)
-				, ContinuationFunction(MoveTemp(InFunction))
+				, ContinuationFunction(Forward<F>(InFunction))
 				, LifetimeMonitor(MoveTemp(InLifetimeMonitor))
 			{
 			}

--- a/Source/SDFutureExtensions/Public/ExpectedFuture.h
+++ b/Source/SDFutureExtensions/Public/ExpectedFuture.h
@@ -200,13 +200,13 @@ namespace SD
 			if (ExecutionDetails.ExecutionPolicy == EExpectedFutureExecutionPolicy::ThreadPool)
 			{
 				using InitWorkType = FutureExtensionTaskGraph::TExpectedFutureInitQueuedWork<F, UnwrappedReturnType>;
-				GThreadPool->AddQueuedWork(new InitWorkType(MoveTemp(Function), Promise, FutureOptions.GetCancellationTokenHandle()));
+				GThreadPool->AddQueuedWork(new InitWorkType(Forward<F>(Function), Promise, FutureOptions.GetCancellationTokenHandle()));
 			}
 			else
 			{
 				using InitTaskType = FutureExtensionTaskGraph::TExpectedFutureInitTask<F, UnwrappedReturnType>;
 				TGraphTask<InitTaskType>::CreateTask()
-					.ConstructAndDispatchWhenReady(MoveTemp(Function), Promise, FutureOptions.GetCancellationTokenHandle());
+					.ConstructAndDispatchWhenReady(Forward<F>(Function), Promise, FutureOptions.GetCancellationTokenHandle());
 			}
 
 			return Future;


### PR DESCRIPTION
Fixes being unable to pass lvalue functions through as continuations.